### PR TITLE
Fix empty hostname in get_slots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1165,7 +1165,7 @@ where
                             return None;
                         };
 
-                        let ip : &str = if ip != "" {&ip} else {&host.as_ref().unwrap()};
+                        let ip = if ip != "" {&ip} else {&host.as_ref().unwrap()};
 
                         Some(build_connection_string(
                             username.as_deref(),


### PR DESCRIPTION
This is an attempt at fixing the problem I mentioned [here](https://github.com/redis-rs/redis-cluster-async/pull/15#issuecomment-1465370800).
I didn't check if it's passing the tests, I only tested in the specific configuration of a single node.